### PR TITLE
develop -> master : 회원 컨트롤러 통합 테스트 작성

### DIFF
--- a/src/main/java/jaeseok/numble/mybox/common/auth/SimpleJwtHandler.java
+++ b/src/main/java/jaeseok/numble/mybox/common/auth/SimpleJwtHandler.java
@@ -2,6 +2,8 @@ package jaeseok.numble.mybox.common.auth;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jaeseok.numble.mybox.common.response.ResponseCode;
+import jaeseok.numble.mybox.common.response.exception.MyBoxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -40,6 +42,10 @@ public class SimpleJwtHandler implements JwtHandler{
 
     @Override
     public Long getId(String jwt) {
+        if (jwt == null || jwt.isBlank()) {
+            throw new MyBoxException(ResponseCode.INVALID_TOKEN);
+        }
+
         String idString = Jwts.parserBuilder()
                 .setSigningKey(Base64.getEncoder().encodeToString(issueKey.getBytes()))
                 .build()

--- a/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
+++ b/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
@@ -135,6 +135,27 @@ class MemberControllerTest {
                         .andExpect(jsonPath("content.memberInfo.usage.mb").isNumber())
                         .andExpect(jsonPath("content.memberInfo.usage.gb").isNumber());
             }
+
+            @Test
+            @DisplayName("패스워드 틀린경우 실패")
+            void failToFaultPassword() throws Exception {
+                // given
+                LoginParam loginParam = new LoginParam(email, "fault_password");
+
+                // when
+                ResultActions resultActions = mockMvc.perform(post("/api/v1/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginParam))
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+                // then
+                resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("success").value(false))
+                        .andExpect(jsonPath("errorCode").value(ResponseCode.INVALID_PASSWORD.getCode()))
+                        .andExpect(jsonPath("content").value(ResponseCode.INVALID_PASSWORD.getMessage()));
+            }
         }
     }
 }

--- a/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
+++ b/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
@@ -219,6 +219,26 @@ class MemberControllerTest {
                         .andExpect(jsonPath("content.usage.mb").isNumber())
                         .andExpect(jsonPath("content.usage.gb").isNumber());
             }
+
+            @Test
+            @DisplayName("헤더에 유효한 토큰이 없는 경우 실패")
+            void failToInvalidToken() throws Exception {
+                // given
+
+
+                // when
+                ResultActions resultActions = mockMvc.perform(get("/api/v1/member")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+                // then
+                resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("success").value(false))
+                        .andExpect(jsonPath("errorCode").value(ResponseCode.INVALID_TOKEN.getCode()))
+                        .andExpect(jsonPath("content").value(ResponseCode.INVALID_TOKEN.getMessage()));
+            }
         }
     }
 }

--- a/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
+++ b/src/test/java/jaeseok/numble/mybox/member/controller/MemberControllerTest.java
@@ -1,8 +1,10 @@
 package jaeseok.numble.mybox.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jaeseok.numble.mybox.common.response.MyBoxResponse;
 import jaeseok.numble.mybox.common.response.ResponseCode;
 import jaeseok.numble.mybox.member.dto.LoginParam;
+import jaeseok.numble.mybox.member.dto.LoginResponse;
 import jaeseok.numble.mybox.member.dto.SignUpParam;
 import jaeseok.numble.mybox.storage.StorageHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -155,6 +158,66 @@ class MemberControllerTest {
                         .andExpect(jsonPath("success").value(false))
                         .andExpect(jsonPath("errorCode").value(ResponseCode.INVALID_PASSWORD.getCode()))
                         .andExpect(jsonPath("content").value(ResponseCode.INVALID_PASSWORD.getMessage()));
+            }
+        }
+
+        @Nested
+        @DisplayName("회원정보 조회")
+        class RetrieveMemberInfo {
+
+            private String jwt;
+
+            @BeforeEach
+            void initMemberAndJwt() throws Exception {
+                // 회원가입
+                SignUpParam signUpParam = new SignUpParam(email, password);
+                mockMvc.perform(post("/api/v1/member")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(signUpParam))
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+                // 로그인
+                LoginParam loginParam = new LoginParam(email, password);
+                ResultActions resultActions = mockMvc.perform(post("/api/v1/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginParam))
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+                String content = resultActions.andReturn().getResponse().getContentAsString();
+                MyBoxResponse myBoxResponse = objectMapper.readValue(content, MyBoxResponse.class);
+
+                String json = objectMapper.writeValueAsString(myBoxResponse.getContent());
+                LoginResponse loginResponse = objectMapper.readValue(json, LoginResponse.class);
+
+                jwt = loginResponse.getJwt();
+            }
+
+            @Test
+            @DisplayName("성공")
+            void success() throws Exception {
+                // given
+
+
+                // when
+                ResultActions resultActions = mockMvc.perform(get("/api/v1/member")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", jwt)
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+                // then
+                resultActions
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("success").value(true))
+                        .andExpect(jsonPath("errorCode").value(ResponseCode.SUCCESS.getCode()))
+                        .andExpect(jsonPath("content.id").isNumber())
+                        .andExpect(jsonPath("content.email").value(email))
+                        .andExpect(jsonPath("content.usage.b").isNumber())
+                        .andExpect(jsonPath("content.usage.kb").isNumber())
+                        .andExpect(jsonPath("content.usage.mb").isNumber())
+                        .andExpect(jsonPath("content.usage.gb").isNumber());
             }
         }
     }


### PR DESCRIPTION
1. 로그인 API 실패케이스 작성
2. 회원정보조회 API 성공 케이스 작성
3. 회원정보조회 API 유효하지 않은 토큰 실패 케이스 작성
4. SimpleJwtHandler 내 jwt null check 로직 추가